### PR TITLE
Blog Archive Layout Fix

### DIFF
--- a/source/blog_archive.html.erb
+++ b/source/blog_archive.html.erb
@@ -9,17 +9,19 @@ title: SavvySoftWorks | Blog Archive
   <div class="blog_archive">
     <div class="row">
     <% blog.articles.each do |article| %>
-      <article class="col s12 m6 blog_col">
-        <h4 class="blog_header center-align">
+      <article class="col s12 m6" style="padding-right: 2em; height:264px;">
+        <h5 class="blog_header center-align">
           <a href="<%= article.url %>"><%= article.title %></a>
-        </h4>
-        <p>
-          <time class="blog_desc"><%= article.date.strftime('%b %e %Y') %></time>
-        </p>
-        <%= article.summary(230, '...') %>
-        <p style="text-align:right;">
-          <a href="<%= article.url %>">Read more</a>
-        </p>
+        </h5>
+        <div class="blog-contents">
+          <p>
+            <time class="blog_desc"><%= article.date.strftime('%b %e %Y') %></time>
+          </p>
+          <%= article.summary(230, '...') %>
+          <p style="text-align:right;">
+            <a href="<%= article.url %>">Read more</a>
+          </p>
+        </div>
       </article>
     <% end %>
     </div>

--- a/source/blog_archive.html.erb
+++ b/source/blog_archive.html.erb
@@ -6,9 +6,10 @@ title: SavvySoftWorks | Blog Archive
   <div class="row">
     <h3>Savvy Blog Archive</h3>
   </div>
-  <div class="row">
+  <div class="blog_archive">
+    <div class="row">
     <% blog.articles.each do |article| %>
-      <article class="col s12 m6" style="padding-right: 2em;">
+      <article class="col s12 m6 blog_col">
         <h4 class="blog_header center-align">
           <a href="<%= article.url %>"><%= article.title %></a>
         </h4>
@@ -21,5 +22,6 @@ title: SavvySoftWorks | Blog Archive
         </p>
       </article>
     <% end %>
+    </div>
   </div>
 </div>

--- a/source/stylesheets/styles.css.scss
+++ b/source/stylesheets/styles.css.scss
@@ -109,7 +109,7 @@ $light: $body;      // off-white
   color: lighten($light, 20);
 }
 
-
+.blog-contents { padding: 0 1em 0 1em; }
 
 .blog, .current_clients, .products {
   h4 {

--- a/source/stylesheets/styles.css.scss
+++ b/source/stylesheets/styles.css.scss
@@ -58,6 +58,14 @@ $light: $body;      // off-white
   background-color: $light;
   .section-title { color: $main; }
   .blog_title, a, a:visited { color: $main; }
+  .blog_archive {
+    .row .col {
+      padding: unset;
+    }
+    .article {
+      margin-bottom: 10px;
+    }
+  }
   a:hover { color: $accent; }
   p {
     a { color: $accent; }


### PR DESCRIPTION
###### Fix column flow problem on Blog Archive page

This fixes the issue of the columns not flowing correctly on the blog archive page. This was caused by the varying height of the blocks. The first post had a long title that flowed to a second line and pushed the third block to the right hand side of the second would be row.

Feexed by adding a fixed height to the blocks, also returned the padding right to the blocks to add separation to the columns. Additionally I added the `.blog-contents` class to the blog body and adding `1em` of padding to give a little more separation.

<img width="1298" alt="screen shot 2017-07-04 at 7 16 07 am" src="https://user-images.githubusercontent.com/13909325/27828134-af496a34-6088-11e7-847c-4a8069cd48a1.png">

###### Needs
- code review
- approval
- deployed